### PR TITLE
Add M-VAVE SMK25-II controller

### DIFF
--- a/src/devices/mvave/__init__.py
+++ b/src/devices/mvave/__init__.py
@@ -1,0 +1,12 @@
+"""
+devices > mvave
+
+Authors:
+* Xinayder
+
+This code is licensed under the GPL v3 license. Refer to the LICENSE file for
+more details.
+"""
+__all__ = ['smk25_ii']
+
+from . import smk25_ii

--- a/src/devices/mvave/smk25_ii/__init__.py
+++ b/src/devices/mvave/smk25_ii/__init__.py
@@ -1,0 +1,16 @@
+"""
+devices > mvave > smk25_ii
+
+M-VAVE SMK25-II
+
+Authors:
+* Xinayder
+
+This code is licensed under the GPL v3 license. Refer to the LICENSE file for
+more details.
+"""
+__all__ = [
+    'smk25_ii'
+]
+
+from . import smk25_ii

--- a/src/devices/mvave/smk25_ii/smk25_ii.py
+++ b/src/devices/mvave/smk25_ii/smk25_ii.py
@@ -1,0 +1,101 @@
+"""
+devices > mvave > smk25_ii > smk25_ii
+
+Definition for the M-VAVE SMK25-II controller.
+
+There are labels for transport controls, but I haven't gotten to adding them.
+They share the same keys as the drum pad.
+
+Authors:
+* Xinayder
+
+This code is licensed under the GPL v3 license. Refer to the LICENSE file for
+more details.
+"""
+
+from typing import Optional
+
+from fl_classes import FlMidiMsg
+
+from common.extension_manager import ExtensionManager
+from control_surfaces import (
+    ChannelAfterTouch,
+    ControlSwitchButton,
+    Fader,
+    FastForwardButton,
+    Knob,
+    MuteButton,
+    PlayButton,
+    RecordButton,
+    RewindButton,
+    SoloButton,
+    StopButton,
+    DirectionLeft,
+    DirectionRight,
+    UndoButton,
+    DrumPad,
+    StandardModWheel,
+    StandardPitchWheel,
+)
+from control_surfaces.event_patterns import BasicPattern, IEventPattern, NotePattern
+from control_surfaces.matchers import BasicControlMatcher, NoteMatcher
+from control_surfaces.value_strategies import (
+    ButtonData2Strategy,
+    Data2Strategy,
+    NoteStrategy,
+)
+from devices.device import Device
+
+class SMK25II(Device):
+    """M-VAVE SMK25-II
+    """
+
+    def __init__(self) -> None:
+        matcher = BasicControlMatcher()
+
+        matcher.addSubMatcher(NoteMatcher())
+        matcher.addControl(StandardPitchWheel.create())
+        matcher.addControl(StandardModWheel.create())
+        matcher.addControl(ChannelAfterTouch.fromChannel(...))
+
+        matcher.addControls([
+            DrumPad(NotePattern(i, 9), NoteStrategy(), (i // 8, i % 8))
+            for i in range(16)
+        ], 10)
+
+
+        for i in range(8):
+            # Knobs
+            matcher.addControl(Knob(
+                BasicPattern(0xB0, 0x1E + i, ...),
+                Data2Strategy(),
+                (0, i)
+            ))
+
+        super().__init__(matcher)
+
+    @classmethod
+    def getDrumPadSize(cls) -> tuple[int, int]:
+        return 2, 8
+
+    @classmethod
+    def matchDeviceName(cls, name: str) -> bool:
+        return name.startswith("SINCO - SINCO SMK25II")
+
+    @classmethod
+    def create(
+        cls,
+        event: Optional[FlMidiMsg] = None,
+        id: Optional[str] = None,
+    ) -> 'Device':
+        return cls()
+
+    def getId(self) -> str:
+        return "MVAVE.SMK25.II"
+
+    @classmethod
+    def getSupportedIds(cls) -> tuple[str, ...]:
+        return ("MVAVE.SMK25.II",)
+
+
+ExtensionManager.devices.register(SMK25II)


### PR DESCRIPTION
This PR adds support for the M-VAVE SMK25-II midi controller.

<img width="1000" height="1000" alt="image" src="https://github.com/user-attachments/assets/91a2a352-d7fd-4847-b196-cf5e4ce85783" />

https://www.cuvave.com/productinfo/1106099.html

The controller has 25 keys, 16 pads, 8 knobs, built-in arpeggiator and smart chords, MCP function, octave control and two sliders. The sliders are setup for pitch bend and mod, respectively. The octave control is built-in and not programmable, same with the arpeggiator and smart chord functions. The MCP button "toggles" a new layer for the drum pad, and both layers are programmable.

I used the factory settings from the controller to add support for it. I thought of adding transport controls, as the 2nd row of the drum pad has some control labels on it, but it requires changing the controller's mappings using the official software.

I haven't tested the sustain pedal function as I don't own a pedal.

The name detection may be different as well, as I haven't tested it on Windows (only on Linux).

Happily taking any suggestions to improve support for this keyboard, as it's my first time using a MIDI keyboard with a DAW.